### PR TITLE
Add `devDependencies` group and update Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,11 @@ updates:
     groups:
       dependencies:
         dependency-type: "production"
+        update-types:
+          - 'minor'
+          - 'patch'
       devDependencies:
         dependency-type: "development"
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/package.json
+++ b/package.json
@@ -3,15 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^6.4.5",
-    "@testing-library/react": "^15.0.7",
-    "@testing-library/user-event": "^14.5.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-network-canvas": "^0.9.4",
     "react-scripts": "5.0.1",
     "uuid": "^9.0.1",
     "web-vitals": "^4.0.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/react": "^15.0.7",
+    "@testing-library/user-event": "^14.5.2",
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Major versions may involve manual intervention, so move them to separate PRs, so as not to hold up minor/patch updates.

Reassign dependencies to `dev` to reduce bundle size.
